### PR TITLE
feat: added deploy sasjs services and improved app packaging

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -45,7 +45,7 @@ export default class Main {
 
   public static startSasJsSeedApp(path?: string) {
     log.info(`Starting ${Main.seedAppTitle}`)
-    log.info('Loading @sasjs/react-seed-app index.html')
+    log.info(`Loading ${Main.seedAppTitle} index.html`)
 
     // INFO: loading @sasjs/react-seed-app index.html
     Main.mainWindow.loadURL(
@@ -99,7 +99,6 @@ export default class Main {
   }
 
   static async deploySasjsServices() {
-    log.info(`seedAppServices: ${seedAppServices}`)
     let services = await readFile(seedAppServices)
 
     try {

--- a/electron/spec/main.spec.ts
+++ b/electron/spec/main.spec.ts
@@ -184,6 +184,32 @@ describe('Main', () => {
     jest
       .spyOn(fileModule, 'createFile')
       .mockImplementation(() => Promise.resolve())
+    jest.spyOn(fileModule, 'readFile').mockImplementation(() =>
+      Promise.resolve(`{
+"appLoc": "/Public/app/react-seed-app",
+"fileTree": {
+  "members": [
+  {
+    "name": "services",
+    "type": "folder",
+    "members": [
+    {
+      "name": "common",
+      "type": "folder",
+      "members": [
+      {
+        "name": "appinit",
+        "type": "service",
+        "code": "code"
+      }
+      ]
+    }
+    ]
+  }
+  ]
+}
+}`)
+    )
 
     mockedAxios.post.mockReturnValueOnce(Promise.resolve({ status: 200 }))
 

--- a/electron/utils/mainPaths.ts
+++ b/electron/utils/mainPaths.ts
@@ -9,15 +9,14 @@ export const serverApiEnvPath = path.join(
   '..',
   '.env'
 )
-export const seedAppPath = path.join(
-  __dirname,
-  '..',
-  '..',
-  'react-seed-app',
-  'build',
-  'index.html'
+export const seedAppFolder = path.join(__dirname, '..', '..', 'react-seed-app')
+export const seedAppPath = path.join(seedAppFolder, 'build', 'index.html')
+export const seedAppServices = path.join(
+  seedAppFolder,
+  'sasjsbuild',
+  'electron.json'
 )
 export const getSasPath = path.join(__dirname, '..', 'getSasPath.html')
-export const serverFolder = path.join('resources', 'appSrc', 'build', 'server')
+export const serverFolder = path.join('resources', 'app', 'build', 'server')
 export const serverPath = path.join(serverFolder, 'api-win.exe')
 export const preloadPath = path.join(__dirname, '..', 'preload.js')

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@sasjs/utils": "2.51.0",
+        "axios": "1.2.1",
         "electron-log": "4.4.8"
       },
       "devDependencies": {
@@ -1661,8 +1662,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -1671,6 +1671,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2203,7 +2213,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2363,7 +2372,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2917,11 +2925,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4380,7 +4406,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4389,7 +4414,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -4820,6 +4844,11 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -7026,14 +7055,23 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
+      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "babel-jest": {
       "version": "29.3.1",
@@ -7425,7 +7463,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -7552,8 +7589,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -7988,11 +8024,15 @@
         "path-exists": "^4.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -9096,14 +9136,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -9418,6 +9456,11 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "optional": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "version": "0.0.1",
   "scripts": {
     "start:electron": "npm run build:electron && ELECTRON_START_URL=http://localhost:3000 && electron build/electron/app.js",
-    "prepare:build:folders": "rm -rf build && mkdir build && cd build && mkdir server && mkdir react-seed-app",
+    "prepare:build:folders": "rimraf build && mkdir build && cd build && mkdir server && mkdir react-seed-app",
     "build:electron": "tsc && cp electron/preload.js build/electron && cp electron/getSasPath.html build/electron",
-    "build:server:api": "cd server/web && npm ci && npm run build && cd ../api npm ci && npm run exe && cp ../executables/api-win.exe ../../build/server",
-    "build:react-seed-app": "cd react-seed-app && npm ci && npm run build && cp -r build ../build/react-seed-app",
+    "build:server:api": "cd server/web && npm ci && npm run build && cd ../api && npm ci && npm run exe && cp ../executables/api-win.exe ../../build/server",
+    "build:react-seed-app": "cd react-seed-app && npm ci && npm run build && cp -r build ../build/react-seed-app && npx sasjs cb -t electron && mkdir ../build/react-seed-app/sasjsbuild && cp sasjsbuild/electron.json ../build/react-seed-app/sasjsbuild",
     "build": "npm run prepare:build:folders && npm run build:electron && npm run build:server:api && npm run build:react-seed-app",
     "package:win:64": "electron-builder build --win --x64 -c.extraMetadata.main=build/electron/app.js",
     "prepare": "git rev-parse --git-dir && git config core.hooksPath ./.git-hooks || true",
@@ -29,7 +29,8 @@
     "nsis": {
       "deleteAppDataOnUninstall": true,
       "oneClick": false
-    }
+    },
+    "asar": false
   },
   "publishConfig": {
     "access": "public"
@@ -60,6 +61,7 @@
   },
   "dependencies": {
     "@sasjs/utils": "2.51.0",
+    "axios": "1.2.1",
     "electron-log": "4.4.8"
   }
 }


### PR DESCRIPTION
## Intent

- deploy sasjs services from `@sasjs/react-seed-app` to `@sasjs/server`.

## Implementation

- Disabled packing the app source code to asar archive and unpacking it later on.
- Added compiled and built sasjs services from `@sasjs/react-seed-app` to app build.
- Added logic to deploy sasjs services to `@sasjs/server`.
- Adjusted unit tests.

## Checks

- [x] Code is formatted correctly (`npm run lint:fix`).
- [x] All unit tests are passing (`npm test`).
- [x] Reviewer is assigned.
